### PR TITLE
Fixed the truncation bug

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ client.on('message', message => {
 const handleCommand = (message: Message) => {
   const [command, argsList] = removePrefix(message.content).split(" ");
 
+  console.log(command);
   switch (command) {
     case "help":
       message.channel.send("Help has not been implemented");
@@ -38,7 +39,7 @@ const handleCommand = (message: Message) => {
 }
 
 const removePrefix = (commandMessage: String) => {
-  return commandMessage.substring(prefix.length, commandMessage.length - prefix.length);
+  return commandMessage.substring(prefix.length, commandMessage.length);
 }
 
 client.login(DISCORD_TOKEN);


### PR DESCRIPTION
Commands were being reduced in size which would cut off the end of
a command. Instead just need to set the start of the substring post
prefix